### PR TITLE
Fix mkdocs build on readthedocs

### DIFF
--- a/Ctl/requirements-docs.txt
+++ b/Ctl/requirements-docs.txt
@@ -1,3 +1,0 @@
-markdown-include>=0.5,<1
-mkdocs>=1.0.0,<2.0.0
-pymdgen<2

--- a/Ctl/requirements-rtd.txt
+++ b/Ctl/requirements-rtd.txt
@@ -1,0 +1,4 @@
+# readthedocs does not properly support poetry and still needs a file like this
+markdown-include>=0.5,<1
+mkdocs>=1.0.0,<2.0.0
+pymdgen<2

--- a/Ctl/requirements-test.txt
+++ b/Ctl/requirements-test.txt
@@ -1,6 +1,0 @@
-codecov>=2.0.5,<3.0.0
-coverage>=4.2,<6
-pytest>=5,<6
-pytest-cov>=2.3.1,<3.0
-tox>=3.0,<4.0
-click>=7,<8

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,8 +8,6 @@ python:
   version: 3.8
   install:
     - method: pip
-      path: "mkdocs>=1.2.3"
-    - method: pip
       path: .
       extra_requirements:
         - docs

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,5 +9,4 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - docs
+      requirements: Ctl/requirements-rtd.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,6 +8,8 @@ python:
   version: 3.8
   install:
     - method: pip
+      path: "mkdocs>=1.2.3"
+    - method: pip
       path: .
       extra_requirements:
         - docs

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,4 +9,4 @@ python:
   install:
     - method: pip
       path: .
-      requirements: Ctl/requirements-rtd.txt
+    - requirements: Ctl/requirements-rtd.txt


### PR DESCRIPTION
readthedocs does not properly support poetry to define requirements for building the docs, thus we need to give it a dedicated requirements file `mkdocs`, `pymdgen` and `markdown-include` requirements.

Also remove some old requirements files that are no longer in use.